### PR TITLE
Relax Semantic Checks

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,3 @@
 # docs: https://github.com/probot/semantic-pull-requests#configuration
 # Always validate the PR title AND all the commits
-titleAndCommits: true
+titleAndCommits: false


### PR DESCRIPTION
Not sure about how other contributors feel but here's a humble proposal to relax the semantic checks and make PRs feel less like a school exam against overall innocent commit notes. Titles will be checked, individual commit titles will not to allows things such as PR issue resolution w/ github default commit messages, etc. 