### PR TITLE
Feature: Add Fluxpipe link to examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,3 +3,4 @@
 This folder contains a list of usage examples related to the Flux repo.
 
 - [library](library): Use Flux as a standalone library in your Go programs.
+- [fluxpipe](https://github.com/metrico/fluXpipe): FluxPipe is a stand-alone Flux API for serverless workers and embedded datasources


### PR DESCRIPTION
- Add [Fluxpipe](https://github.com/metrico/fluXpipe) to Flux library examples
