### PR TITLE
Disable semantic checks on commits

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,3 @@
 # docs: https://github.com/probot/semantic-pull-requests#configuration
 # Always validate the PR title AND all the commits
-titleAndCommits: true
+titleAndCommits: false

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,4 @@
 # docs: https://github.com/probot/semantic-pull-requests#configuration
 # Always validate the PR title AND all the commits
+titleOnly: true
 titleAndCommits: false


### PR DESCRIPTION
Semantic checks for commits are not useful in this fork, switching to `titleOnly` mode to allow recovering from errors. 
Any PRs to upstream Flux will get squashed to comply.
